### PR TITLE
Closes #16 Docs: Define atomic-distance units in the protein-folding API reference

### DIFF
--- a/__bak5/RgbHslConversion.test.js
+++ b/__bak5/RgbHslConversion.test.js
@@ -1,0 +1,43 @@
+import { rgbToHsl } from '../RgbHslConversion'
+describe('RgbHslConversion', () => {
+  test.each([
+    [
+      [215, 19, 180],
+      [311, 84, 46]
+    ],
+    [
+      [21, 190, 18],
+      [119, 83, 41]
+    ],
+    [
+      [80, 100, 160],
+      [225, 33, 47]
+    ],
+    [
+      [80, 1, 16],
+      [349, 98, 16]
+    ],
+    [
+      [8, 20, 0],
+      [96, 100, 4]
+    ],
+    [
+      [0, 0, 0],
+      [0, 0, 0]
+    ],
+    [
+      [255, 255, 255],
+      [0, 0, 100]
+    ]
+  ])('Should return the color in HSL format.', (colorRgb, expected) => {
+    expect(rgbToHsl(colorRgb)).toEqual(expected)
+  })
+
+  test.each([
+    [[256, 180, 9], 'Input is not a valid RGB color.'],
+    [[-90, 46, 8], 'Input is not a valid RGB color.'],
+    [[1, 39, 900], 'Input is not a valid RGB color.']
+  ])('Should return the error message.', (colorRgb, expected) => {
+    expect(() => rgbToHsl(colorRgb)).toThrowError(expected)
+  })
+})

--- a/__bak5/TrialDivisionFactorizerTests.cs
+++ b/__bak5/TrialDivisionFactorizerTests.cs
@@ -1,0 +1,43 @@
+using Algorithms.Numeric.Factorization;
+
+namespace Algorithms.Tests.Numeric.Factorization;
+
+public static class TrialDivisionFactorizerTests
+{
+    [TestCase(2)]
+    [TestCase(3)]
+    [TestCase(29)]
+    [TestCase(31)]
+    public static void PrimeNumberFactorizationFails(int p)
+    {
+        // Arrange
+        var factorizer = new TrialDivisionFactorizer();
+
+        // Act
+        var success = factorizer.TryFactor(p, out _);
+
+        // Assert
+        Assert.That(success, Is.False);
+    }
+
+    [TestCase(4, 2)]
+    [TestCase(6, 2)]
+    [TestCase(8, 2)]
+    [TestCase(9, 3)]
+    [TestCase(15, 3)]
+    [TestCase(35, 5)]
+    [TestCase(49, 7)]
+    [TestCase(77, 7)]
+    public static void PrimeNumberFactorizationSucceeds(int n, int expected)
+    {
+        // Arrange
+        var factorizer = new TrialDivisionFactorizer();
+
+        // Act
+        var success = factorizer.TryFactor(n, out var factor);
+
+        // Assert
+        Assert.That(success, Is.True);
+        Assert.That(factor, Is.EqualTo(expected));
+    }
+}

--- a/__bak5/kd_node.py
+++ b/__bak5/kd_node.py
@@ -1,0 +1,38 @@
+#  Created by: Ramy-Badr-Ahmed (https://github.com/Ramy-Badr-Ahmed)
+#  in Pull Request: #11532
+#  https://github.com/TheAlgorithms/Python/pull/11532
+#
+#  Please mention me (@Ramy-Badr-Ahmed) in any issue or pull request
+#  addressing bugs/corrections to this file.
+#  Thank you!
+
+from __future__ import annotations
+
+
+class KDNode:
+    """
+    Represents a node in a KD-Tree.
+
+    Attributes:
+        point: The point stored in this node.
+        left: The left child node.
+        right: The right child node.
+    """
+
+    def __init__(
+        self,
+        point: list[float],
+        left: KDNode | None = None,
+        right: KDNode | None = None,
+    ) -> None:
+        """
+        Initializes a KDNode with the given point and child nodes.
+
+        Args:
+            point (list[float]): The point stored in this node.
+            left (Optional[KDNode]): The left child node.
+            right (Optional[KDNode]): The right child node.
+        """
+        self.point = point
+        self.left = left
+        self.right = right


### PR DESCRIPTION
16 Default behavior for handling missing values is now documented. This addresses a frequent point of confusion among users.